### PR TITLE
Realtime CLI logs 

### DIFF
--- a/config/config-store/config.json
+++ b/config/config-store/config.json
@@ -24,6 +24,10 @@
     "host": "",
     "port": "22000"
   },
+  "logger": {
+    "host": "",
+    "port": "22001"
+  },
   "connectors": {
     "routers": [
       "fake",

--- a/config/nginx/ernest.local
+++ b/config/nginx/ernest.local
@@ -6,6 +6,10 @@ upstream backendmonitor {
     server monit:22000      weight=5;
 }
 
+upstream backendlogger {
+    server logger:22001      weight=5;
+}
+
 server {
     listen 443 ssl;
     server_name ERNESTHOST;
@@ -29,9 +33,25 @@ server {
             error_page 504 =200 @eventsource-close-graceful;
     }
 
+    location /logs {
+        proxy_pass  http://backendlogger;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            proxy_read_timeout 3600s;
+            chunked_transfer_encoding off;
+            proxy_buffering off;
+            proxy_cache off;
+            error_page 504 =200 @logsource-close-graceful;
+    }
+
     location @eventsource-close-graceful {
         add_header Content-Type text/event-stream;
         return 200;
     }
 
+    location @logsource-close-graceful {
+        add_header Content-Type text/event-stream;
+        return 200;
+    }
 }

--- a/definition.yml
+++ b/definition.yml
@@ -343,11 +343,16 @@ repos:
     branch: master
     links:
       - nats
+    ports:
+      - 22001:22001
+    depends:
+      - config-store
     environment:
       NATS_URI: 'nats://nats:4222'
       ERNEST_LOG_FILE: '/var/logs/ernest.log'
       ERNEST_LOG_CONFIG: '/etc/ernest/'
       ERNEST_CRYPTO_KEY: CRYPTO_KEY_TEMPLATE
+      JWT_SECRET: 'GENERATEDJWTSECRET'
     volumes:
       - ./logs/:/var/logs/
       - ./config/:/etc/ernest/

--- a/template.yml
+++ b/template.yml
@@ -22,5 +22,6 @@ services:
     links:
       - api-gateway:api-gateway
       - monit:monit
+      - logger:logger
     ports:
       - 443:443


### PR DESCRIPTION
This feature implements [`ernest-cli log`](https://github.com/ernestio/ernest/issues/192) which will open a pipe against ernest server in order to print "real time" logs.

This feature requires changes on:

- [x] [ernest-cli](https://github.com/ernestio/ernest-cli/pull/71)
- [x] [api-gateway](https://github.com/ernestio/api-gateway/pull/56)
- [x] [logger](https://github.com/ernestio/logger/pull/19)
- [x] ernest (current)
- [x] [ernest-vagrant](https://github.com/ernestio/ernest-vagrant/pull/50)

In order to test it you may want to change the definition.yml file, so repos / branches are pointing to forks under my user like:
- api-gateway: kaitokojiro/api-gateway::develop
- logger: kaitokojiro/logger::realtime

Plus ernest-cli must be built from kaitokojiro/ernest-cli::develop branch.

Once you have a docker built environment, you can easily test it by running `ernest-cli log` which will show you an output like:

<img width="352" alt="screen shot 2017-03-08 at 11 11 41" src="https://cloud.githubusercontent.com/assets/16296979/23699601/0cd01f68-03f0-11e7-90a8-0d0e5be228e9.png">

Or `ernest log --raw` that will print a simpler non-colored output:
<img width="575" alt="screen shot 2017-03-08 at 12 04 14" src="https://cloud.githubusercontent.com/assets/16296979/23701514/6602fd7e-03f7-11e7-9675-7f84ca551d30.png">
