### PR TITLE
Display all related services badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,34 @@
 # Ernest
 
-master:  [![CircleCI](https://circleci.com/gh/ernestio/ernest/tree/master.svg?style=shield)](https://circleci.com/gh/ernestio/ernest/tree/master)  
-develop: [![CircleCI](https://circleci.com/gh/ernestio/ernest/tree/develop.svg?style=shield)](https://circleci.com/gh/ernestio/ernest/tree/develop)
-
 Full Stack Application Orchestration
 
 ## Quickstart
 
 Follow the instructions on the [download page](http://docs.ernest.io/downloads/) to install ernest, then take a look at our [getting started page](http://docs.ernest.io/getting-started/) to see how to work with ernest.
+
+## Build status
+
+
+| Project | master | develop |
+| ------- | ------ | ------- |
+| [all-all-aws-connector](https://github.com/ernestio/all-all-aws-connector) | [![CircleCI](https://circleci.com/gh/ernestio/all-all-aws-connector/tree/master.svg?style=shield)](https://circleci.com/gh/ernestio/all-all-aws-connector/ernest/tree/master) | [![CircleCI](https://circleci.com/gh/ernestio/all-all-aws-connector/tree/develop.svg?style=shield)](https://circleci.com/gh/ernestio/all-all-aws-connector/ernest/tree/develop) |
+| [all-all-azure-connector](https://github.com/ernestio/all-all-azure-connector) | [![CircleCI](https://circleci.com/gh/ernestio/all-all-azure-connector/tree/master.svg?style=shield)](https://circleci.com/gh/ernestio/all-all-azure-connector/ernest/tree/master) | [![CircleCI](https://circleci.com/gh/ernestio/all-all-azure-connector/tree/develop.svg?style=shield)](https://circleci.com/gh/ernestio/all-all-azure-connector/ernest/tree/develop) |
+| [all-all-fake-connector](https://github.com/ernestio/all-all-fake-connector) | [![CircleCI](https://circleci.com/gh/ernestio/all-all-fake-connector/tree/master.svg?style=shield)](https://circleci.com/gh/ernestio/all-all-fake-connector/ernest/tree/master) | [![CircleCI](https://circleci.com/gh/ernestio/all-all-fake-connector/tree/develop.svg?style=shield)](https://circleci.com/gh/ernestio/all-all-fake-connector/ernest/tree/develop) |
+| [all-all-vcloud-connector](https://github.com/ernestio/all-all-vcloud-connector) | [![CircleCI](https://circleci.com/gh/ernestio/all-all-vcloud-connector/tree/master.svg?style=shield)](https://circleci.com/gh/ernestio/all-all-vcloud-connector/ernest/tree/master) | [![CircleCI](https://circleci.com/gh/ernestio/all-all-vcloud-connector/tree/develop.svg?style=shield)](https://circleci.com/gh/ernestio/all-all-vcloud-connector/ernest/tree/develop) |
+| [api-gateway](https://github.com/ernestio/api-gateway) | [![CircleCI](https://circleci.com/gh/ernestio/api-gateway/tree/master.svg?style=shield)](https://circleci.com/gh/ernestio/api-gateway/ernest/tree/master) | [![CircleCI](https://circleci.com/gh/ernestio/api-gateway/tree/develop.svg?style=shield)](https://circleci.com/gh/ernestio/api-gateway/ernest/tree/develop) |
+| [authenticator](https://github.com/ernestio/authenticator) | [![CircleCI](https://circleci.com/gh/ernestio/authenticator/tree/master.svg?style=shield)](https://circleci.com/gh/ernestio/authenticator/ernest/tree/master) | [![CircleCI](https://circleci.com/gh/ernestio/authenticator/tree/develop.svg?style=shield)](https://circleci.com/gh/ernestio/authenticator/ernest/tree/develop) |
+| [authorization-store](https://github.com/ernestio/authorization-store) | [![CircleCI](https://circleci.com/gh/ernestio/authorization-store/tree/master.svg?style=shield)](https://circleci.com/gh/ernestio/authorization-store/ernest/tree/master) | [![CircleCI](https://circleci.com/gh/ernestio/authorization-store/tree/develop.svg?style=shield)](https://circleci.com/gh/ernestio/authorization-store/ernest/tree/develop) |
+| [config-store](https://github.com/ernestio/config-store) | [![CircleCI](https://circleci.com/gh/ernestio/config-store/tree/master.svg?style=shield)](https://circleci.com/gh/ernestio/config-store/ernest/tree/master) | [![CircleCI](https://circleci.com/gh/ernestio/config-store/tree/develop.svg?style=shield)](https://circleci.com/gh/ernestio/config-store/ernest/tree/develop) |
+| [datacenter-store](https://github.com/ernestio/datacenter-store) | [![CircleCI](https://circleci.com/gh/ernestio/datacenter-store/tree/master.svg?style=shield)](https://circleci.com/gh/ernestio/datacenter-store/ernest/tree/master) | [![CircleCI](https://circleci.com/gh/ernestio/datacenter-store/tree/develop.svg?style=shield)](https://circleci.com/gh/ernestio/datacenter-store/ernest/tree/develop) |
+| [definition-mapper](https://github.com/ernestio/definition-mapper) | [![CircleCI](https://circleci.com/gh/ernestio/definition-mapper/tree/master.svg?style=shield)](https://circleci.com/gh/ernestio/definition-mapper/ernest/tree/master) | [![CircleCI](https://circleci.com/gh/ernestio/definition-mapper/tree/develop.svg?style=shield)](https://circleci.com/gh/ernestio/definition-mapper/ernest/tree/develop) |
+| [logger](https://github.com/ernestio/logger) | [![CircleCI](https://circleci.com/gh/ernestio/logger/tree/master.svg?style=shield)](https://circleci.com/gh/ernestio/logger/ernest/tree/master) | [![CircleCI](https://circleci.com/gh/ernestio/logger/tree/develop.svg?style=shield)](https://circleci.com/gh/ernestio/logger/ernest/tree/develop) |
+| [monit](https://github.com/ernestio/monit) | [![CircleCI](https://circleci.com/gh/ernestio/monit/tree/master.svg?style=shield)](https://circleci.com/gh/ernestio/monit/ernest/tree/master) | [![CircleCI](https://circleci.com/gh/ernestio/monit/tree/develop.svg?style=shield)](https://circleci.com/gh/ernestio/monit/ernest/tree/develop) |
+| [scheduler](https://github.com/ernestio/scheduler) | [![CircleCI](https://circleci.com/gh/ernestio/scheduler/tree/master.svg?style=shield)](https://circleci.com/gh/ernestio/scheduler/ernest/tree/master) | [![CircleCI](https://circleci.com/gh/ernestio/scheduler/tree/develop.svg?style=shield)](https://circleci.com/gh/ernestio/scheduler/ernest/tree/develop) |
+| [service-store](https://github.com/ernestio/service-store) | [![CircleCI](https://circleci.com/gh/ernestio/service-store/tree/master.svg?style=shield)](https://circleci.com/gh/ernestio/service-store/ernest/tree/master) | [![CircleCI](https://circleci.com/gh/ernestio/service-store/tree/develop.svg?style=shield)](https://circleci.com/gh/ernestio/service-store/ernest/tree/develop) |
+| [usage-store](https://github.com/ernestio/usage-store) | [![CircleCI](https://circleci.com/gh/ernestio/usage-store/tree/master.svg?style=shield)](https://circleci.com/gh/ernestio/usage-store/ernest/tree/master) | [![CircleCI](https://circleci.com/gh/ernestio/usage-store/tree/develop.svg?style=shield)](https://circleci.com/gh/ernestio/usage-store/ernest/tree/develop) |
+| [user-store](https://github.com/ernestio/user-store) | [![CircleCI](https://circleci.com/gh/ernestio/user-store/tree/master.svg?style=shield)](https://circleci.com/gh/ernestio/user-store/ernest/tree/master) | [![CircleCI](https://circleci.com/gh/ernestio/user-store/tree/develop.svg?style=shield)](https://circleci.com/gh/ernestio/user-store/ernest/tree/develop) |
+| [ernest-cli](https://github.com/ernestio/ernest-cli) | [![CircleCI](https://circleci.com/gh/ernestio/ernest-cli/tree/master.svg?style=shield)](https://circleci.com/gh/ernestio/ernest-cli/ernest/tree/master) | [![CircleCI](https://circleci.com/gh/ernestio/ernest-cli/tree/develop.svg?style=shield)](https://circleci.com/gh/ernestio/ernest-cli/ernest/tree/develop) |
+
 
 ## Contributing
 
@@ -31,4 +52,3 @@ Code and documentation copyright since 2015 r3labs.io authors.
 
 Code released under
 [the Mozilla Public License Version 2.0](LICENSE).
-


### PR DESCRIPTION
An easy way to access all related repos and a quick view of the CI status.

You can have a quick look at the result in [here](https://github.com/ernestio/ernest/tree/all_badges)